### PR TITLE
docs: say what the repository is for

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@ Hello from Hexlet action!
 
 [Made with hello World JavaScript action repository](https://github.com/actions/hello-world-javascript-action).
 
+## Зачем это нужно
+
+Простейший GitHub Action: выводит строку `Hello from Hexlet!` и больше ничего.
+
+Именно бесполезность здесь и есть смысл. В курсе по GitHub Actions его
+подключают к своему воркфлоу, чтобы разобраться, как экшены вообще
+подключаются, не отвлекаясь на то, что экшен делает.
+
+Подключается так:
+
+```yaml
+- uses: hexlet-components/hello-from-hexlet-action@release
+```
+
 ## Usage
 
 ```yaml


### PR DESCRIPTION
The README opened with requirements or install steps, so a reader arriving from a lesson could set the project up without ever learning what it demonstrates or why it exists. That section is now first.